### PR TITLE
Fix coobobo break

### DIFF
--- a/all-in-one.sh
+++ b/all-in-one.sh
@@ -9,6 +9,9 @@ java -jar checker/target/checker-1.0-SNAPSHOT.jar
 #remove all cache_peer
 sed -i.bak '/cache_peer/d' /etc/squid3/squid.conf
 
+count=$(cat data/proxy.squid | grep HIGH_ANONYMITY | wc -l)
+echo Updated $count proxies.
+
 cat data/proxy.squid | grep HIGH_ANONYMITY | sed 's/#HIGH_ANONYMITY.*//' >> /etc/squid3/squid.conf
 
 squid3 -k reconfigure

--- a/checker/src/main/java/com/mrkid/proxy/checker/ProxyChecker.java
+++ b/checker/src/main/java/com/mrkid/proxy/checker/ProxyChecker.java
@@ -127,9 +127,9 @@ public class ProxyChecker {
         // Bugfix: If host name contains blanks, new HttpHost() below will throw exception and promise won't
         // complete forever.
         if (TextUtils.containsBlanks(proxy.getHost())) {
-        	logger.warn("cancelling proxy: " + proxy + " since it contains blanks in host name");
-        	promise.cancel(true);
-        	return promise;
+            logger.warn("cancelling proxy: " + proxy + " since it contains blanks in host name");
+            promise.cancel(true);
+            return promise;
         }
 
         HttpContext httpContext = HttpClientContext.create();

--- a/crawler/src/main/java/com/mrkid/proxy/crawler/ProxyCrawlerApp.java
+++ b/crawler/src/main/java/com/mrkid/proxy/crawler/ProxyCrawlerApp.java
@@ -71,8 +71,8 @@ public class ProxyCrawlerApp {
         new HashSet<>(proxies).stream()
                 .filter(p -> StringUtils.isNotBlank(p.getHost()))
                 .forEach(p -> {
-                	this.evalHostIfNeeded(engine, p);
-                	proxyService.saveProxy(p);
+                    this.evalHostIfNeeded(engine, p);
+                    proxyService.saveProxy(p);
                 });
     }
     
@@ -80,15 +80,15 @@ public class ProxyCrawlerApp {
      * Extra post-processing to handle JS "document.write" case
      */
     private void evalHostIfNeeded(ScriptEngine engine, ProxyDTO proxy) {
-    	if (proxy.getHost().indexOf("document.write") != -1) {
-    	    String result;
-			try {
-				result = (String) engine.eval("var document = { write: function(s) {return s;} }; " + proxy.getHost());
-				proxy.setHost(result);
-			} catch (ScriptException e) {
-				logger.warn("Failed evaling javascript on host name of proxy: " + proxy);
-			}
-    	}
+        if (proxy.getHost().indexOf("document.write") != -1) {
+            String result;
+            try {
+                result = (String) engine.eval("var document = { write: function(s) {return s;} }; " + proxy.getHost());
+                proxy.setHost(result);
+            } catch (ScriptException e) {
+                logger.warn("Failed evaling javascript on host name of proxy: " + proxy);
+            }
+        }
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
* Improve ProxyChecker robustness by fixing a bug: if host name contains blanks, new HttpHost() below will throw exception and promise won't complete forever;
* Eval javascript if met `document.write` in host name;
* Print proxies count in all-in-one.sh.

