### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM minimum2scp/squid
+
+# From https://github.com/dockerfile/java/blob/master/oracle-java8/Dockerfile
+RUN \
+  sudo apt-get install software-properties-common -y && \
+  echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
+  add-apt-repository -y ppa:webupd8team/java && \
+  apt-get update && \
+  apt-get install -y --allow-unauthenticated oracle-java8-installer && \
+  rm -rf /var/lib/apt/lists/* && \
+  rm -rf /var/cache/oracle-jdk8-installer
+
+# Define commonly used JAVA_HOME variable
+ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+
+# Wifiyou
+RUN \
+  ln -s /etc/squid /etc/squid3 && \
+  mkdir -p /opt/wifiyou/proxy-checker/crawler/target/ && \
+  mkdir -p /opt/wifiyou/proxy-checker/checker/target/
+
+# Define working directory.
+WORKDIR /opt/wifiyou/proxy-checker/
+
+COPY crawler/target/crawler-1.0-SNAPSHOT.jar crawler/target/
+COPY checker/target/checker-1.0-SNAPSHOT.jar checker/target/
+COPY all-in-one.sh update
+
+RUN chmod +x /opt/wifiyou/proxy-checker/update

--- a/README.md
+++ b/README.md
@@ -53,4 +53,16 @@ It will
 
   If a proxy fail to check 3 times recently, it is considered as inactive.
  
+## Docker
 
+It's convenient to run the proxy server in docker.
+
+* Install docker
+* `mvn clean -Dmaven.test.skip package`
+* `docker build -t auto-proxy .`
+* (optional) save/load the docker image
+* `docker run -d -p 3128:3128 --name wifiyou-proxy auto-proxy`
+* `docker exec wifiyou-proxy ./update`
+* 127.0.0.1:3128 is ready to use as proxy server
+* Run `docker exec wifiyou-proxy ./update` anytime to update proxy list
+* Run `docker stop wifiyou-proxy` and `docker start wifiyou-proxy` to stop/start


### PR DESCRIPTION
* Install docker
* `mvn clean -Dmaven.test.skip package`
* `docker build -t auto-proxy .`
* (optional) save/load the docker image
* `docker run -d -p 3128:3128 --name wifiyou-proxy auto-proxy`
* `docker exec wifiyou-proxy ./update`
* 127.0.0.1:3128 is ready to use as proxy server
* Run `docker exec wifiyou-proxy ./update` anytime to update proxy list
* Run `docker stop wifiyou-proxy` and `docker start wifiyou-proxy` to stop/start
